### PR TITLE
Make xev TCP transport read/write works

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,8 +32,8 @@
         //     .hash = "1220fd9f66231bcae161c8ef630a528179d6435e4e083f784e8ff0cd46c0990ed9b5",
         // },
         .libxev = .{
-            .url = "https://github.com/mitchellh/libxev/archive/refs/heads/main.zip",
-            .hash = "1220d220fe297775b574b0312faaf5afcc0044cbda650d0558ec2dda8fb1a6dc1228",
+            .url = "git+https://github.com/mitchellh/libxev#c6e8719a321088691829e2e4bf4d13eed5d4fb69",
+            .hash = "122040cf4300fa02f4ebade2c68d94d04f4e97dab3ca75d2a6935fb022c1af2f2bcb",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,7 +33,7 @@
         // },
         .libxev = .{
             .url = "https://github.com/mitchellh/libxev/archive/refs/heads/main.zip",
-            .hash = "122040cf4300fa02f4ebade2c68d94d04f4e97dab3ca75d2a6935fb022c1af2f2bcb",
+            .hash = "1220d220fe297775b574b0312faaf5afcc0044cbda650d0558ec2dda8fb1a6dc1228",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,8 +32,8 @@
         //     .hash = "1220fd9f66231bcae161c8ef630a528179d6435e4e083f784e8ff0cd46c0990ed9b5",
         // },
         .libxev = .{
-            .url = "git+https://github.com/mitchellh/libxev#c6e8719a321088691829e2e4bf4d13eed5d4fb69",
-            .hash = "122040cf4300fa02f4ebade2c68d94d04f4e97dab3ca75d2a6935fb022c1af2f2bcb",
+            .url = "git+https://github.com/mitchellh/libxev#db6a52bafadf00360e675fefa7926e8e6c0e9931",
+            .hash = "12206029de146b685739f69b10a6f08baee86b3d0a5f9a659fa2b2b66c9602078bbf",
         },
     },
     .paths = .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -4,6 +4,10 @@
 const std = @import("std");
 const testing = std.testing;
 
+pub const xev_transport = @import("transport/tcp/libxev.zig");
+pub const future = @import("utils/future.zig");
+pub const queue = @import("utils/queue_mpsc.zig");
+
 test {
     std.testing.refAllDeclsRecursive(@This());
 }

--- a/src/transport/tcp/libxev.zig
+++ b/src/transport/tcp/libxev.zig
@@ -383,7 +383,7 @@ pub const XevTransport = struct {
         };
     }
 
-    pub fn serve(self: *XevTransport, addr: std.net.Address) !void {
+    pub fn listen(self: *XevTransport, addr: std.net.Address) !void {
         const server = try self.allocator.create(TCP);
         server.* = try TCP.init(addr);
         try server.bind(addr);
@@ -603,9 +603,9 @@ test "echo client and server with multiple clients" {
 
     const client_addr1 = try std.net.Address.parseIp("0.0.0.0", 8083);
 
-    const server_thr = try std.Thread.spawn(.{}, XevTransport.serve, .{ &server, addr });
-    const client_thr = try std.Thread.spawn(.{}, XevTransport.serve, .{ &client, client_addr });
-    const client_thr1 = try std.Thread.spawn(.{}, XevTransport.serve, .{ &client1, client_addr1 });
+    const server_thr = try std.Thread.spawn(.{}, XevTransport.listen, .{ &server, addr });
+    const client_thr = try std.Thread.spawn(.{}, XevTransport.listen, .{ &client, client_addr });
+    const client_thr1 = try std.Thread.spawn(.{}, XevTransport.listen, .{ &client1, client_addr1 });
 
     const server_addr = try std.net.Address.parseIp("127.0.0.1", 8081);
 

--- a/src/transport/tcp/libxev.zig
+++ b/src/transport/tcp/libxev.zig
@@ -139,7 +139,7 @@ pub const SocketChannel = struct {
         c: *xev.Completion,
         socket: xev.TCP,
         buf: xev.ReadBuffer,
-        r: xev.TCP.ReadError!usize,
+        r: xev.ReadError!usize,
     ) xev.CallbackAction {
         const self = self_.?;
         const n = r catch |err| switch (err) {
@@ -178,7 +178,7 @@ pub const SocketChannel = struct {
         c: *xev.Completion,
         socket: xev.TCP,
         buf: xev.ReadBuffer,
-        r: xev.TCP.ReadError!usize,
+        r: xev.ReadError!usize,
     ) xev.CallbackAction {
         const self = self_.?;
         const n = r catch |err| switch (err) {
@@ -217,7 +217,7 @@ pub const SocketChannel = struct {
         c: *xev.Completion,
         s: xev.TCP,
         _: xev.WriteBuffer,
-        r: xev.TCP.WriteError!usize,
+        r: xev.WriteError!usize,
     ) xev.CallbackAction {
         std.debug.print("write callback\n", .{});
         _ = l;
@@ -242,7 +242,7 @@ pub const SocketChannel = struct {
         l: *xev.Loop,
         c: *xev.Completion,
         s: xev.TCP,
-        r: xev.TCP.ShutdownError!void,
+        r: xev.ShutdownError!void,
     ) xev.CallbackAction {
         _ = r catch |err| {
             std.debug.print("Error shutting down: {}\n", .{err});
@@ -258,7 +258,7 @@ pub const SocketChannel = struct {
         l: *xev.Loop,
         c: *xev.Completion,
         socket: xev.TCP,
-        r: xev.TCP.CloseError!void,
+        r: xev.CloseError!void,
     ) xev.CallbackAction {
         std.debug.print("close callback\n", .{});
         _ = l;
@@ -507,7 +507,7 @@ pub const XevTransport = struct {
         _: *xev.Loop,
         c: *xev.Completion,
         socket: xev.TCP,
-        r: xev.TCP.ConnectError!void,
+        r: xev.ConnectError!void,
     ) xev.CallbackAction {
         const self = self_.?;
         defer self.transport.allocator.destroy(c);
@@ -538,7 +538,7 @@ pub const XevTransport = struct {
         self_: ?*XevTransport,
         _: *xev.Loop,
         _: *xev.Completion,
-        r: xev.TCP.AcceptError!xev.TCP,
+        r: xev.AcceptError!xev.TCP,
     ) xev.CallbackAction {
         const self = self_.?;
         _ = r catch |err| {

--- a/src/transport/tcp/libxev.zig
+++ b/src/transport/tcp/libxev.zig
@@ -1,0 +1,640 @@
+const std = @import("std");
+const xev = @import("xev");
+const Intrusive = @import("../../utils/queue_mpsc.zig").Intrusive;
+const Queue = Intrusive(AsyncIOQueueNode);
+const TCP = xev.TCP;
+const Allocator = std.mem.Allocator;
+const ThreadPool = xev.ThreadPool;
+const Future = @import("../../utils/future.zig").Future;
+
+/// Memory pools for things that need stable pointers
+const BufferPool = std.heap.MemoryPool([4096]u8);
+const CompletionPool = std.heap.MemoryPool(xev.Completion);
+const TCPPool = std.heap.MemoryPool(xev.TCP);
+const ChannelPool = std.heap.MemoryPool(SocketChannel);
+
+/// SocketChannelManager keeps track of all the inbound and outbound socket channels .
+/// It also keeps track of all the listening sockets.
+pub const SocketChannelManager = struct {
+    listeners: struct {
+        mutex: std.Thread.Mutex,
+        m: std.StringHashMap(*TCP),
+    },
+    sockets: struct {
+        mutex: std.Thread.Mutex,
+        l: std.ArrayList(*SocketChannel),
+    },
+    socket_pool: TCPPool,
+    channel_pool: ChannelPool,
+    allocator: Allocator,
+
+    pub fn init(allocator: Allocator) SocketChannelManager {
+        return SocketChannelManager{
+            .listeners = .{
+                .mutex = .{},
+                .m = std.StringHashMap(*TCP).init(allocator),
+            },
+            .sockets = .{
+                .mutex = .{},
+                .l = std.ArrayList(*SocketChannel).init(allocator),
+            },
+            .socket_pool = TCPPool.init(allocator),
+            .channel_pool = ChannelPool.init(allocator),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *SocketChannelManager) void {
+        self.sockets.mutex.lock();
+        for (self.sockets.l.items) |socket_channel| {
+            socket_channel.deinit();
+            self.channel_pool.destroy(socket_channel);
+        }
+        self.sockets.l.deinit();
+        self.sockets.mutex.unlock();
+        self.listeners.mutex.lock();
+        var iter = self.listeners.m.iterator();
+        while (iter.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.destroy(entry.value_ptr.*);
+        }
+        self.listeners.m.deinit();
+        self.listeners.mutex.unlock();
+        self.socket_pool.deinit();
+        self.channel_pool.deinit();
+    }
+};
+
+/// SocketChannel represents a socket channel. It is used to send and receive messages.
+pub const SocketChannel = struct {
+    socket: *TCP,
+    transport: *XevTransport,
+    read_buf: []u8,
+    is_auto_read: bool,
+    is_initiator: bool,
+
+    pub fn init(self: *SocketChannel, socket: *TCP, transport: *XevTransport, is_initiator: bool, is_auto_read: bool) void {
+        self.socket = socket;
+        self.transport = transport;
+        self.is_auto_read = is_auto_read;
+        self.is_initiator = is_initiator;
+        self.read_buf = transport.buffer_pool.create() catch unreachable;
+    }
+
+    pub fn set_auto_read(self: *SocketChannel, is_auto_read: bool) void {
+        self.is_auto_read = is_auto_read;
+    }
+
+    pub fn deinit(self: *SocketChannel) void {
+        self.transport.destroyBuf(self.read_buf);
+        self.transport.destroySocket(self.socket);
+    }
+
+    // pub fn write(self: *SocketChannel, buf: []const u8) void {
+    //     if (self.transport.isInLoopThread()) {
+    //         const c = self.transport.completion_pool.create() catch unreachable;
+    //         self.socket.write(&self.transport.loop, c, .{ .slice = buf }, SocketChannel, self, writeCallback);
+    //     } else {
+    //         const element = self.transport.allocator.create(AsyncIOQueueElem) catch unreachable;
+    //         element.* = AsyncIOQueueElem{
+    //             .next = null,
+    //             .op = .{ .write = .{ .channel = self, .buffer = buf } },
+    //         };
+    //         self.transport.async_task_queue.push(element);
+    //         self.transport.async_io_notifier.notify() catch |err| {
+    //             std.debug.print("Error notifying async io: {}\n", .{err});
+    //         };
+    //     }
+    // }
+    //
+    // pub fn read(self: *SocketChannel) void {
+    //     if (self.transport.isInLoopThread()) {
+    //         const c = self.transport.completion_pool.create() catch unreachable;
+    //
+    //         if (self.is_initiator) {
+    //             self.socket.read(&self.transport.loop, c, .{ .slice = self.read_buf[0..] }, SocketChannel, self, outboundChannelReadCallback);
+    //         } else {
+    //             self.socket.read(&self.transport.loop, c, .{ .slice = self.read_buf[0..] }, SocketChannel, self, inboundChannelReadCallback);
+    //         }
+    //     } else {
+    //         const element = self.transport.allocator.create(AsyncIOQueueElem) catch unreachable;
+    //         element.* = AsyncIOQueueElem{
+    //             .next = null,
+    //             .op = .{ .read = .{ .channel = self } },
+    //         };
+    //         self.transport.async_task_queue.push(element);
+    //         self.transport.async_io_notifier.notify() catch |err| {
+    //             std.debug.print("Error notifying async io: {}\n", .{err});
+    //         };
+    //     }
+    // }
+
+    fn outboundChannelReadCallback(
+        self_: ?*SocketChannel,
+        loop: *xev.Loop,
+        c: *xev.Completion,
+        socket: xev.TCP,
+        buf: xev.ReadBuffer,
+        r: xev.TCP.ReadError!usize,
+    ) xev.CallbackAction {
+        const self = self_.?;
+        const n = r catch |err| switch (err) {
+            error.EOF => {
+                socket.shutdown(loop, c, SocketChannel, self, shutdownCallback);
+                return .disarm;
+            },
+
+            else => {
+                if (self.transport.handler.io_error) |cb| {
+                    cb(self, err);
+                }
+                socket.shutdown(loop, c, SocketChannel, self, shutdownCallback);
+                std.log.warn("server read unexpected err={}", .{err});
+                return .disarm;
+            },
+        };
+
+        if (self.transport.handler.outbound_channel_read) |cb| {
+            cb(self, buf.slice[0..n]);
+        }
+
+        if (self.is_auto_read) {
+            return .rearm;
+        } else {
+            return .disarm;
+        }
+    }
+
+    fn inboundChannelReadCallback(
+        self_: ?*SocketChannel,
+        loop: *xev.Loop,
+        c: *xev.Completion,
+        socket: xev.TCP,
+        buf: xev.ReadBuffer,
+        r: xev.TCP.ReadError!usize,
+    ) xev.CallbackAction {
+        std.debug.print("read callback\n", .{});
+        const self = self_.?;
+        const n = r catch |err| switch (err) {
+            error.EOF => {
+                std.debug.print("EOF\n", .{});
+                self.transport.destroyBuf(buf.slice);
+                socket.shutdown(loop, c, SocketChannel, self, shutdownCallback);
+                return .disarm;
+            },
+
+            else => {
+                if (self.transport.handler.io_error) |cb| {
+                    cb(self, err);
+                }
+                std.debug.print("Error reading: {}\n", .{err});
+                self.transport.destroyBuf(buf.slice);
+                socket.shutdown(loop, c, SocketChannel, self, shutdownCallback);
+                std.log.warn("server read unexpected err={}", .{err});
+                return .disarm;
+            },
+        };
+
+        if (self.transport.handler.outbound_channel_read) |cb| {
+            cb(self, buf.slice[0..n]);
+        }
+
+        if (self.is_auto_read) {
+            return .rearm;
+        } else {
+            return .disarm;
+        }
+    }
+
+    fn writeCallback(
+        self_: ?*SocketChannel,
+        l: *xev.Loop,
+        c: *xev.Completion,
+        s: xev.TCP,
+        _: xev.WriteBuffer,
+        r: xev.TCP.WriteError!usize,
+    ) xev.CallbackAction {
+        std.debug.print("write callback\n", .{});
+        _ = l;
+        _ = s;
+        _ = r catch |err| {
+            std.debug.print("Error writing: {}\n", .{err});
+        };
+
+        // We do nothing for write, just put back objects into the pool.
+        const self = self_.?;
+        self.transport.completion_pool.destroy(c);
+        // self.transport.buffer_pool.destroy(
+        //     @alignCast(
+        //         @as(*[4096]u8, @ptrFromInt(@intFromPtr(buf.slice.ptr))),
+        //     ),
+        // );
+        return .disarm;
+    }
+
+    fn shutdownCallback(
+        self_: ?*SocketChannel,
+        l: *xev.Loop,
+        c: *xev.Completion,
+        s: xev.TCP,
+        r: xev.TCP.ShutdownError!void,
+    ) xev.CallbackAction {
+        _ = r catch |err| {
+            std.debug.print("Error shutting down: {}\n", .{err});
+        };
+
+        const self = self_.?;
+        s.close(l, c, SocketChannel, self, closeCallback);
+        return .disarm;
+    }
+
+    fn closeCallback(
+        self_: ?*SocketChannel,
+        l: *xev.Loop,
+        c: *xev.Completion,
+        socket: xev.TCP,
+        r: xev.TCP.CloseError!void,
+    ) xev.CallbackAction {
+        std.debug.print("close callback\n", .{});
+        _ = l;
+        _ = r catch unreachable;
+        _ = socket;
+
+        const self = self_.?;
+
+        self.deinit();
+        //TODO: need remove it from socket channel list
+        self.transport.completion_pool.destroy(c);
+        return .disarm;
+    }
+};
+
+/// ChannelHandler is used to implement the protocol specific behavior of a channel.
+pub const ChannelHandler = struct {
+    inbound_channel_read: ?*const fn (*SocketChannel, []const u8) void = null,
+    outbound_channel_read: ?*const fn (*SocketChannel, []const u8) void = null,
+    io_error: ?*const fn (*SocketChannel, anyerror) void = null,
+};
+
+/// Options for the transport.
+pub const Options = struct {
+    backlog: u31,
+    inbound_channel_options: struct {
+        is_auto_read: bool = true,
+    },
+    outbound_channel_options: struct {
+        is_auto_read: bool = true,
+    },
+};
+
+/// AsyncIOQueueNode is used to store the operation to be performed on the transport.
+pub const AsyncIOQueueNode = struct {
+    const Self = @This();
+    next: ?*Self = null,
+    op: union(enum) {
+        connect: struct {
+            address: std.net.Address,
+            channel_future: *Future(*SocketChannel),
+        },
+        // write: struct {
+        //     buffer: []const u8,
+        //     channel: *SocketChannel,
+        // },
+        // read: struct {
+        //     channel: *SocketChannel,
+        // },
+    },
+};
+
+const ConnectCallbackData = struct {
+    transport: *XevTransport,
+    channel_future: *Future(*SocketChannel),
+};
+
+pub const XevTransport = struct {
+    loop: xev.Loop,
+    buffer_pool: BufferPool,
+    completion_pool: CompletionPool,
+    threadPool: *xev.ThreadPool,
+    socket_channel_manager: SocketChannelManager,
+    options: Options,
+    stop_notifier: xev.Async,
+    async_io_notifier: xev.Async,
+    async_task_queue: *Queue,
+    handler: ChannelHandler,
+    mutex: std.Thread.Mutex,
+    c_accept: *xev.Completion,
+    allocator: Allocator,
+
+    pub fn init(allocator: Allocator, opts: Options, handler: ChannelHandler) !XevTransport {
+        const thread_pool = try allocator.create(ThreadPool);
+        thread_pool.* = ThreadPool.init(.{});
+        const loop_opts = xev.Options{
+            .thread_pool = thread_pool,
+        };
+        const server_loop = try xev.Loop.init(loop_opts);
+        const shutdown_notifier = try xev.Async.init();
+        const async_io_notifier = try xev.Async.init();
+        var q = try allocator.create(Queue);
+        q.init();
+        return XevTransport{
+            .mutex = .{},
+            .c_accept = try allocator.create(xev.Completion),
+            .buffer_pool = BufferPool.init(allocator),
+            .completion_pool = CompletionPool.init(allocator),
+            .loop = server_loop,
+            .threadPool = thread_pool,
+            .socket_channel_manager = SocketChannelManager.init(allocator),
+            .options = opts,
+            .stop_notifier = shutdown_notifier,
+            .async_io_notifier = async_io_notifier,
+            .async_task_queue = q,
+            .handler = handler,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *XevTransport) void {
+        self.stop_notifier.deinit();
+        self.async_io_notifier.deinit();
+        self.loop.deinit();
+        self.threadPool.shutdown();
+        self.threadPool.deinit();
+        self.allocator.destroy(self.threadPool);
+        self.allocator.destroy(self.c_accept);
+    }
+
+    pub fn dial(self: *XevTransport, addr: std.net.Address, channel_future: *Future(*SocketChannel)) !void {
+        const node = try self.allocator.create(AsyncIOQueueNode);
+        node.* = AsyncIOQueueNode{
+            .next = null,
+            .op = .{
+                .connect = .{
+                    .address = addr,
+                    .channel_future = channel_future,
+                },
+            },
+        };
+
+        self.async_task_queue.push(node);
+
+        self.async_io_notifier.notify() catch |err| {
+            std.debug.print("Error notifying async io: {}\n", .{err});
+        };
+    }
+
+    pub fn serve(self: *XevTransport, addr: std.net.Address) !void {
+        const server = try self.allocator.create(TCP);
+        server.* = try TCP.init(addr);
+        try server.bind(addr);
+        try server.listen(self.options.backlog);
+
+        const c_accept = try self.allocator.create(xev.Completion);
+        defer self.allocator.destroy(c_accept);
+        server.accept(&self.loop, c_accept, XevTransport, self, acceptCallback);
+
+        self.socket_channel_manager.listeners.mutex.lock();
+        const key = try formatAddress(addr, self.allocator);
+        // defer self.allocator.free(key);
+        self.socket_channel_manager.listeners.m.put(key, server) catch |err| {
+            std.debug.print("Error adding server to map: {}\n", .{err});
+        };
+        self.socket_channel_manager.listeners.mutex.unlock();
+
+        const c_stop = try self.completion_pool.create();
+        self.stop_notifier.wait(&self.loop, c_stop, XevTransport, self, &stopCallback);
+        const c_async = try self.completion_pool.create();
+        self.async_io_notifier.wait(&self.loop, c_async, XevTransport, self, &asyncIOCallback);
+        try self.loop.run(.until_done);
+    }
+
+    pub fn stop(self: *XevTransport) void {
+        self.stop_notifier.notify() catch |err| {
+            std.debug.print("Error notifying stop: {}\n", .{err});
+        };
+    }
+
+    fn asyncIOCallback(
+        self_: ?*XevTransport,
+        loop: *xev.Loop,
+        _: *xev.Completion,
+        r: xev.Async.WaitError!void,
+    ) xev.CallbackAction {
+        _ = r catch unreachable;
+        const self = self_.?;
+
+        while (self.async_task_queue.pop()) |node| {
+            switch (node.op) {
+                .connect => |*conn| {
+                    // std.debug.print("Connect address{}\n", .{conn.*});
+                    const address = conn.address;
+                    var socket = TCP.init(address) catch unreachable;
+                    const channel_future = conn.channel_future;
+                    // channel_future.* = Future(*SocketChannel).init();
+
+                    const connect_cb_data = self.allocator.create(ConnectCallbackData) catch unreachable;
+                    connect_cb_data.* = ConnectCallbackData{
+                        .transport = self,
+                        .channel_future = channel_future,
+                    };
+
+                    const c = self.allocator.create(xev.Completion) catch unreachable;
+                    socket.connect(loop, c, address, ConnectCallbackData, connect_cb_data, connectCallback);
+                },
+                // .write => |*w| {
+                //     const c = self.completion_pool.create() catch unreachable;
+                //     const channel = w.channel;
+                //     const buffer = w.buffer;
+                //
+                //     // Move data out of elem before the write call
+                //     // self.queue_element_pool.destroy(elem);
+                //
+                //     channel.socket.write(&self.loop, c, .{ .slice = buffer }, SocketChannel, channel, SocketChannel.writeCallback);
+                // },
+                // .read => |*read| {
+                //     const c = self.completion_pool.create() catch unreachable;
+                //     const channel = read.channel;
+                //
+                //     // Move data out of elem before the read call
+                //     // self.queue_element_pool.destroy(elem);
+                //
+                //     if (channel.is_initiator) {
+                //         channel.socket.read(&self.loop, c, .{ .slice = channel.read_buf[0..] }, SocketChannel, channel, SocketChannel.outboundChannelReadCallback);
+                //     } else {
+                //         channel.socket.read(&self.loop, c, .{ .slice = channel.read_buf[0..] }, SocketChannel, channel, SocketChannel.inboundChannelReadCallback);
+                //     }
+                // },
+            }
+
+            self.allocator.destroy(node);
+        }
+
+        return .rearm;
+    }
+
+    fn stopCallback(
+        self_: ?*XevTransport,
+        loop: *xev.Loop,
+        c: *xev.Completion,
+        r: xev.Async.WaitError!void,
+    ) xev.CallbackAction {
+        _ = r catch unreachable;
+        const self = self_.?;
+
+        loop.stop();
+        self.completion_pool.destroy(c);
+
+        self.socket_channel_manager.deinit();
+        self.buffer_pool.deinit();
+        self.completion_pool.deinit();
+        return .disarm;
+    }
+
+    fn connectCallback(
+        self_: ?*ConnectCallbackData,
+        _: *xev.Loop,
+        c: *xev.Completion,
+        socket: xev.TCP,
+        r: xev.TCP.ConnectError!void,
+    ) xev.CallbackAction {
+        const self = self_.?;
+        defer self.transport.allocator.destroy(c);
+        _ = r catch |err| {
+            // TODO: Handle timeout error and retry
+            std.debug.print("Error connecting: {}\n", .{err});
+            self.channel_future.completeError(err);
+            return .disarm;
+        };
+
+        const s = self.transport.socket_channel_manager.socket_pool.create() catch unreachable;
+        s.* = socket;
+        const channel = self.transport.socket_channel_manager.channel_pool.create() catch unreachable;
+        channel.init(s, self.transport, true, self.transport.options.outbound_channel_options.is_auto_read);
+        self.transport.socket_channel_manager.sockets.mutex.lock();
+        self.transport.socket_channel_manager.sockets.l.append(channel) catch unreachable;
+        self.transport.socket_channel_manager.sockets.mutex.unlock();
+        self.channel_future.complete(channel);
+
+        if (self.transport.options.outbound_channel_options.is_auto_read) {
+            // channel.read();
+        }
+
+        return .disarm;
+    }
+
+    fn acceptCallback(
+        self_: ?*XevTransport,
+        _: *xev.Loop,
+        _: *xev.Completion,
+        r: xev.TCP.AcceptError!xev.TCP,
+    ) xev.CallbackAction {
+        const self = self_.?;
+        _ = r catch |err| {
+            // TODO: Check why this is happening and determine if we should retry
+            std.debug.print("Error accepting: {}\n", .{err});
+            return .rearm;
+        };
+
+        const socket = self.socket_channel_manager.socket_pool.create() catch unreachable;
+        socket.* = r catch unreachable;
+        const channel = self.socket_channel_manager.channel_pool.create() catch unreachable;
+        channel.init(socket, self, false, self.options.inbound_channel_options.is_auto_read);
+        self.socket_channel_manager.sockets.mutex.lock();
+        self.socket_channel_manager.sockets.l.append(channel) catch unreachable;
+        self.socket_channel_manager.sockets.mutex.unlock();
+
+        if (self.options.inbound_channel_options.is_auto_read) {
+            // channel.read();
+        }
+
+        return .rearm;
+    }
+
+    fn destroyBuf(self: *XevTransport, buf: []const u8) void {
+        self.buffer_pool.destroy(
+            @alignCast(
+                @as(*[4096]u8, @ptrFromInt(@intFromPtr(buf.ptr))),
+            ),
+        );
+    }
+
+    fn destroySocket(self: *XevTransport, socket: *xev.TCP) void {
+        self.socket_channel_manager.socket_pool.destroy(
+            @alignCast(socket),
+        );
+    }
+
+    pub fn formatAddress(addr: std.net.Address, allocator: Allocator) ![]const u8 {
+        const addr_str = try std.fmt.allocPrint(allocator, "{}", .{addr});
+        return addr_str;
+    }
+};
+
+test "echo client and server with multiple clients" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    const opts = Options{
+        .backlog = 128,
+        .inbound_channel_options = .{ .is_auto_read = true },
+        .outbound_channel_options = .{ .is_auto_read = true },
+    };
+    const handler = ChannelHandler{
+        // .inbound_channel_read = struct {
+        //     fn callback(channel: *SocketChannel, buf: []const u8) void {
+        //         channel.write(buf); // Remove the catch since write() returns void
+        //     }
+        // }.callback,
+        .inbound_channel_read = null,
+        .outbound_channel_read = null,
+    };
+    var server = try XevTransport.init(allocator, opts, handler);
+    defer server.deinit();
+
+    const addr = try std.net.Address.parseIp("0.0.0.0", 8081);
+
+    var client = try XevTransport.init(allocator, opts, handler);
+    defer client.deinit();
+
+    const client_addr = try std.net.Address.parseIp("0.0.0.0", 8082);
+
+    var client1 = try XevTransport.init(allocator, opts, handler);
+    defer client1.deinit();
+
+    const client_addr1 = try std.net.Address.parseIp("0.0.0.0", 8083);
+
+    const server_thr = try std.Thread.spawn(.{}, XevTransport.serve, .{ &server, addr });
+    const client_thr = try std.Thread.spawn(.{}, XevTransport.serve, .{ &client, client_addr });
+    const client_thr1 = try std.Thread.spawn(.{}, XevTransport.serve, .{ &client1, client_addr1 });
+
+    const server_addr = try std.net.Address.parseIp("127.0.0.1", 8081);
+
+    var channel_future = Future(*SocketChannel).init();
+    try client.dial(server_addr, &channel_future);
+
+    var channel_future1 = Future(*SocketChannel).init();
+    try client1.dial(server_addr, &channel_future1);
+
+    _ = try channel_future.wait();
+    _ = try channel_future1.wait();
+
+    std.time.sleep(100_000_000);
+    server.socket_channel_manager.sockets.mutex.lock();
+    try std.testing.expectEqual(2, server.socket_channel_manager.sockets.l.items.len);
+    server.socket_channel_manager.sockets.mutex.unlock();
+    server.socket_channel_manager.listeners.mutex.lock();
+    try std.testing.expectEqual(1, server.socket_channel_manager.listeners.m.count());
+    server.socket_channel_manager.listeners.mutex.unlock();
+    client.socket_channel_manager.sockets.mutex.lock();
+    try std.testing.expectEqual(1, client.socket_channel_manager.sockets.l.items.len);
+    client.socket_channel_manager.sockets.mutex.unlock();
+    client.socket_channel_manager.listeners.mutex.lock();
+    try std.testing.expectEqual(1, client.socket_channel_manager.listeners.m.count());
+    client.socket_channel_manager.listeners.mutex.unlock();
+    server.stop();
+    client.stop();
+    client1.stop();
+    server_thr.join();
+    client_thr.join();
+    client_thr1.join();
+}

--- a/src/utils/future.zig
+++ b/src/utils/future.zig
@@ -1,0 +1,167 @@
+const std = @import("std");
+
+pub fn Future(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        value: ?T = null,
+        err: ?anyerror = null,
+        completed: bool = false,
+        mutex: std.Thread.Mutex = .{},
+        condition: std.Thread.Condition = .{},
+        onSuccess: ?*const fn (T) void = null,
+        onError: ?*const fn (anyerror) void = null,
+        free_on_complete: bool = false,
+        allocator: ?std.mem.Allocator = null,
+
+        pub fn init() Self {
+            return Self{};
+        }
+
+        pub fn initWithCleanup(allocator: std.mem.Allocator) Self {
+            return Self{
+                .free_on_complete = true,
+                .allocator = allocator,
+            };
+        }
+
+        pub fn listen(self: *Self, on_success: ?*const fn (T) void, on_error: ?*const fn (anyerror) void) void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            self.onSuccess = on_success;
+            self.onError = on_error;
+
+            if (self.completed) {
+                if (self.value) |v| {
+                    if (self.onSuccess) |cb| cb(v);
+                } else if (self.err) |e| {
+                    if (self.onError) |cb| cb(e);
+                }
+            }
+        }
+
+        pub fn complete(self: *Self, data: T) void {
+            self.mutex.lock();
+            defer {
+                if (self.free_on_complete and self.allocator != null) {
+                    self.allocator.?.destroy(self);
+                } else {
+                    self.mutex.unlock();
+                }
+            }
+
+            self.value = data;
+            self.completed = true;
+            if (self.onSuccess) |cb| cb(data);
+            self.condition.signal();
+        }
+
+        pub fn completeError(self: *Self, err: anyerror) void {
+            self.mutex.lock();
+            defer {
+                if (self.free_on_complete and self.allocator != null) {
+                    self.allocator.?.destroy(self);
+                } else {
+                    self.mutex.unlock();
+                }
+            }
+
+            self.err = err;
+            self.completed = true;
+            if (self.onError) |cb| cb(err);
+            self.condition.signal();
+        }
+
+        pub fn wait(self: *Self) !T {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            while (!self.completed) {
+                self.condition.wait(&self.mutex);
+            }
+
+            if (self.err) |e| return e;
+            return self.value.?;
+        }
+    };
+}
+
+test "Future basic completion" {
+    var future = Future(u32).init();
+    future.complete(42);
+    const result = try future.wait();
+    try std.testing.expectEqual(@as(u32, 42), result);
+}
+
+test "Future error handling" {
+    var future = Future([]const u8).init();
+    future.completeError(error.OutOfMemory);
+    try std.testing.expectError(error.OutOfMemory, future.wait());
+}
+
+test "Future async completion" {
+    var future = Future([]const u8).init();
+
+    const thread = try std.Thread.spawn(.{}, struct {
+        fn run(f: *Future([]const u8)) void {
+            std.time.sleep(10 * std.time.ns_per_ms);
+            f.complete("done");
+        }
+    }.run, .{&future});
+
+    const result = try future.wait();
+    try std.testing.expectEqualStrings("done", result);
+    thread.join();
+}
+
+test "Future with callbacks" {
+    const TestNamespace = struct {
+        var called: bool = false;
+    };
+
+    const Context = struct {
+        pub fn callback(value: u32) void {
+            TestNamespace.called = true;
+            std.testing.expectEqual(@as(u32, 123), value) catch unreachable;
+        }
+    };
+
+    var future = Future(u32).init();
+    TestNamespace.called = false;
+
+    future.listen(
+        Context.callback,
+        null,
+    );
+
+    future.complete(123);
+    try std.testing.expect(TestNamespace.called);
+}
+
+test "Future with error callback" {
+    const TestNamespace = struct {
+        var called: bool = false;
+        var got_error: ?anyerror = null;
+    };
+
+    const Context = struct {
+        pub fn onError(err: anyerror) void {
+            TestNamespace.called = true;
+            TestNamespace.got_error = err;
+        }
+    };
+
+    var future = Future(u32).init();
+    TestNamespace.called = false;
+    TestNamespace.got_error = null;
+
+    future.listen(
+        null,
+        Context.onError,
+    );
+
+    future.completeError(error.OutOfMemory);
+    try std.testing.expect(TestNamespace.called);
+    try std.testing.expectEqual(TestNamespace.got_error.?, error.OutOfMemory);
+}

--- a/src/utils/queue_mpsc.zig
+++ b/src/utils/queue_mpsc.zig
@@ -1,0 +1,117 @@
+/// Copied from https://github.com/mitchellh/libxev under the MIT license.
+const std = @import("std");
+const assert = std.debug.assert;
+
+/// An intrusive MPSC (multi-provider, single consumer) queue implementation.
+/// The type T must have a field "next" of type `?*T`.
+///
+/// This is an implementatin of a Vyukov Queue[1].
+/// TODO(mitchellh): I haven't audited yet if I got all the atomic operations
+/// correct. I was short term more focused on getting something that seemed
+/// to work; I need to make sure it actually works.
+///
+/// For those unaware, an intrusive variant of a data structure is one in which
+/// the data type in the list has the pointer to the next element, rather
+/// than a higher level "node" or "container" type. The primary benefit
+/// of this (and the reason we implement this) is that it defers all memory
+/// management to the caller: the data structure implementation doesn't need
+/// to allocate "nodes" to contain each element. Instead, the caller provides
+/// the element and how its allocated is up to them.
+///
+/// [1]: https://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue
+pub fn Intrusive(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        /// Head is the front of the queue and tail is the back of the queue.
+        head: *T,
+        tail: *T,
+        stub: T,
+
+        /// Initialize the queue. This requires a stable pointer to itself.
+        /// This must be called before the queue is used concurrently.
+        pub fn init(self: *Self) void {
+            self.head = &self.stub;
+            self.tail = &self.stub;
+            self.stub.next = null;
+        }
+
+        /// Push an item onto the queue. This can be called by any number
+        /// of producers.
+        pub fn push(self: *Self, v: *T) void {
+            @atomicStore(?*T, &v.next, null, .unordered);
+            const prev = @atomicRmw(*T, &self.head, .Xchg, v, .acq_rel);
+            @atomicStore(?*T, &prev.next, v, .release);
+        }
+
+        /// Pop the first in element from the queue. This must be called
+        /// by only a single consumer at any given time.
+        pub fn pop(self: *Self) ?*T {
+            var tail = @atomicLoad(*T, &self.tail, .unordered);
+            var next_ = @atomicLoad(?*T, &tail.next, .acquire);
+            if (tail == &self.stub) {
+                const next = next_ orelse return null;
+                @atomicStore(*T, &self.tail, next, .unordered);
+                tail = next;
+                next_ = @atomicLoad(?*T, &tail.next, .acquire);
+            }
+
+            if (next_) |next| {
+                @atomicStore(*T, &self.tail, next, .release);
+                tail.next = null;
+                return tail;
+            }
+
+            const head = @atomicLoad(*T, &self.head, .unordered);
+            if (tail != head) return null;
+            self.push(&self.stub);
+
+            next_ = @atomicLoad(?*T, &tail.next, .acquire);
+            if (next_) |next| {
+                @atomicStore(*T, &self.tail, next, .unordered);
+                tail.next = null;
+                return tail;
+            }
+
+            return null;
+        }
+    };
+}
+
+test Intrusive {
+    const testing = std.testing;
+
+    // Types
+    const Elem = struct {
+        const Self = @This();
+        next: ?*Self = null,
+    };
+    const Queue = Intrusive(Elem);
+    var q: Queue = undefined;
+    q.init();
+
+    // Elems
+    var elems: [10]Elem = .{.{}} ** 10;
+
+    // One
+    try testing.expect(q.pop() == null);
+    q.push(&elems[0]);
+    try testing.expect(q.pop().? == &elems[0]);
+    try testing.expect(q.pop() == null);
+
+    // Two
+    try testing.expect(q.pop() == null);
+    q.push(&elems[0]);
+    q.push(&elems[1]);
+    try testing.expect(q.pop().? == &elems[0]);
+    try testing.expect(q.pop().? == &elems[1]);
+    try testing.expect(q.pop() == null);
+
+    // // Interleaved
+    try testing.expect(q.pop() == null);
+    q.push(&elems[0]);
+    try testing.expect(q.pop().? == &elems[0]);
+    q.push(&elems[1]);
+    try testing.expect(q.pop().? == &elems[1]);
+    try testing.expect(q.pop() == null);
+}


### PR DESCRIPTION
This PR fix #6 

This PR completes the channel read and write operations based on the previous [PR](https://github.com/zen-eth/zig-libp2p/pulls). Currently, the design of `ChannelHandler` is flawed and cannot customize structures with member variables, so the test uses printout for the time being.