### PR TITLE
fix: update libxev version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -27,7 +27,7 @@
     .dependencies = .{
         .libxev = .{
             .url = "https://github.com/mitchellh/libxev/archive/refs/heads/main.zip",
-            .hash = "libxev-0.0.0-86vtc2UaEwDfiTKX3iBI-s_hdzfzWQUarT3MUrmUQl-Q",
+            .hash = "libxev-0.0.0-86vtcx8dEwDfl6p4tGVxCygft8oOsggfba9JO-k28J2x",
         },
         .zmultiformats = .{
             .url = "https://github.com/zen-eth/multiformats-zig/archive/main.tar.gz",


### PR DESCRIPTION
It seems like `libxev` updated their version and after ran `zig fetch --save https://github.com/mitchellh/libxev/archive/refs/heads/main.zip` it's able to build.