### PR TITLE
feat: use multiaddr in QUIC transport

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Zig Test and Benchmark
+name: Zig-libp2p CI
 
 on:
   push:
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Zig
-        uses: actions/cache@v3
+        id: cache
+        uses: actions/cache@v4
         with:
           path: ~/zig
           key: ${{ runner.os }}-zig-${{ env.ZIG_VERSION }}
@@ -33,7 +34,7 @@ jobs:
         run: echo "${HOME}/zig" >> $GITHUB_PATH
 
       - name: Cache Zig build artifacts
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             zig-cache
@@ -48,4 +49,4 @@ jobs:
         run: zig build test --summary all
 
       - name: Building
-        run: zig build -Doptimize=ReleaseFast
+        run: zig build -Doptimize=ReleaseSafe

--- a/build.zig
+++ b/build.zig
@@ -53,6 +53,12 @@ pub fn build(b: *std.Build) void {
         },
     );
 
+    const peer_id_dep = b.dependency("peer_id", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const peer_id_module = peer_id_dep.module("peer-id");
+
     const root_module = b.addModule("zig-libp2p", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
@@ -63,6 +69,7 @@ pub fn build(b: *std.Build) void {
     root_module.addImport("ssl", ssl_module);
     root_module.addIncludePath(lsquic_dep.path("include"));
     root_module.addImport("gremlin", gremlin_module);
+    root_module.addImport("peer_id", peer_id_module);
 
     const libp2p_lib = b.addLibrary(.{
         .name = "zig-libp2p",
@@ -87,6 +94,7 @@ pub fn build(b: *std.Build) void {
     libp2p_exe.root_module.addImport("multiformats", zmultiformats_module);
     libp2p_exe.root_module.addImport("ssl", ssl_module);
     libp2p_exe.root_module.addImport("gremlin", gremlin_module);
+    libp2p_exe.root_module.addImport("peer_id", peer_id_module);
     libp2p_exe.step.dependOn(&protobuf.step);
 
     libp2p_exe.linkLibrary(lsquic_artifact);
@@ -131,6 +139,8 @@ pub fn build(b: *std.Build) void {
     libp2p_lib_unit_tests.root_module.addImport("xev", libxev_module);
     libp2p_lib_unit_tests.root_module.addImport("multiformats", zmultiformats_module);
     libp2p_lib_unit_tests.root_module.addImport("ssl", ssl_module);
+    libp2p_lib_unit_tests.root_module.addImport("gremlin", gremlin_module);
+    libp2p_lib_unit_tests.root_module.addImport("peer_id", peer_id_module);
 
     libp2p_lib_unit_tests.linkLibrary(lsquic_artifact);
     libp2p_lib_unit_tests.linkSystemLibrary("zlib");
@@ -148,6 +158,8 @@ pub fn build(b: *std.Build) void {
     libp2p_exe_unit_tests.root_module.addImport("xev", libxev_module);
     libp2p_exe_unit_tests.root_module.addImport("multiformats", zmultiformats_module);
     libp2p_exe_unit_tests.root_module.addImport("gremlin", gremlin_module);
+    libp2p_exe_unit_tests.root_module.addImport("peer_id", peer_id_module);
+    libp2p_exe_unit_tests.root_module.addImport("ssl", ssl_module);
     libp2p_exe_unit_tests.step.dependOn(&protobuf.step);
 
     libp2p_exe_unit_tests.root_module.addImport("ssl", ssl_module);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,8 +30,8 @@
             .hash = "libxev-0.0.0-86vtcx8dEwDfl6p4tGVxCygft8oOsggfba9JO-k28J2x",
         },
         .zmultiformats = .{
-            .url = "https://github.com/zen-eth/multiformats-zig/archive/main.tar.gz",
-            .hash = "zmultiformats-0.1.0-6A8pca4MBQAOeUuxppEgwy_j0U_FVNK6h7swLzzDrCZ0",
+            .url = "git+https://github.com/zen-eth/multiformats-zig#acb3945e7f1b2fed18f92f05d321cd1a0a4e32e1",
+            .hash = "zmultiformats-0.1.0-6A8pcdwUBQAgUTaQC5RhH3XBZUgo6-3zQQRO953yVyMA",
         },
         .gremlin = .{
             .url = "git+https://github.com/octopus-foundation/gremlin.zig#fccfe2659f24497199d86404e0ef7dbc79e033d2",
@@ -40,6 +40,10 @@
         .lsquic = .{
             .url = "git+https://github.com/zen-eth/lsquic.git#585b456f165acd02a68b64c56cf126a596718fac",
             .hash = "lsquic-0.0.0-jO7gdp8dAADM0lQxub9u0psWph_fUuNTbYWMvpNE_VtY",
+        },
+        .peer_id = .{
+            .url = "git+https://github.com/zen-eth/peer-id#3f9be40ec19f5a85298102dde7c0259f064fb3d8",
+            .hash = "peer_id-0.0.0-jlAlYI9cAACWW0w-GZaf3xAuwXNZhOOGKQtm3CvqcdiK",
         },
     },
     .paths = .{

--- a/src/protocols/discard.zig
+++ b/src/protocols/discard.zig
@@ -240,7 +240,8 @@ pub const DiscardSender = struct {
 
 test "discard protocol using switch" {
     const allocator = std.testing.allocator;
-    const switch1_listen_address = try std.net.Address.parseIp4("127.0.0.1", 8767);
+    const switch1_listen_address = try Multiaddr.fromString(allocator, "/ip4/0.0.0.0/udp/8767");
+    defer switch1_listen_address.deinit();
 
     var loop: io_loop.ThreadEventLoop = undefined;
     try loop.init(std.testing.allocator);
@@ -372,7 +373,8 @@ test "discard protocol using switch" {
 
 test "discard protocol using switch with 1MB data" {
     const allocator = std.testing.allocator;
-    const switch1_listen_address = try std.net.Address.parseIp4("127.0.0.1", 8777);
+    const switch1_listen_address = try Multiaddr.fromString(allocator, "/ip4/0.0.0.0/udp/8777");
+    defer switch1_listen_address.deinit();
 
     var loop: io_loop.ThreadEventLoop = undefined;
     try loop.init(std.testing.allocator);
@@ -495,7 +497,8 @@ test "discard protocol using switch with 1MB data" {
 
 test "no supported protocols error" {
     const allocator = std.testing.allocator;
-    const switch1_listen_address = try std.net.Address.parseIp4("127.0.0.1", 8867);
+    const switch1_listen_address = try Multiaddr.fromString(allocator, "/ip4/0.0.0.0/udp/8867");
+    defer switch1_listen_address.deinit();
 
     var loop: io_loop.ThreadEventLoop = undefined;
     try loop.init(std.testing.allocator);
@@ -521,7 +524,6 @@ test "no supported protocols error" {
 
     var discard_handler = DiscardProtocolHandler.init(allocator);
     defer discard_handler.deinit();
-    // try switch1.addProtocolHandler("discard", discard_handler.any());
 
     try switch1.listen(switch1_listen_address, null, struct {
         pub fn callback(_: ?*anyopaque, _: anyerror!?*anyopaque) void {

--- a/src/switch.zig
+++ b/src/switch.zig
@@ -9,6 +9,7 @@ const quic = libp2p.transport.quic;
 const protocols = libp2p.protocols;
 const Allocator = std.mem.Allocator;
 const mss = protocols.mss;
+const Multiaddr = @import("multiformats").multiaddr.Multiaddr;
 
 /// The Switch struct is the main entry point for managing connections and protocol handlers.
 /// It acts as a central hub for handling incoming and outgoing connections,
@@ -184,7 +185,7 @@ pub const Switch = struct {
 
     const ConnectCallbackCtx = struct {
         network_switch: *Switch,
-        address: std.net.Address,
+        address: Multiaddr,
         proposed_protocols: []const []const u8,
         user_callback_ctx: ?*anyopaque,
         user_callback: *const fn (callback_ctx: ?*anyopaque, controller: anyerror!?*anyopaque) void,
@@ -206,10 +207,14 @@ pub const Switch = struct {
                 .active_callback_ctx = null,
             };
 
-            const address_str = std.fmt.allocPrint(self.network_switch.allocator, "{}", .{self.address}) catch unreachable;
+            const address_str = self.address.toString(self.network_switch.allocator) catch |err| {
+                std.log.warn("Failed to convert address to string: {}", .{err});
+                self.user_callback(self.user_callback_ctx, err);
+                return;
+            };
             self.network_switch.outgoing_connections.put(address_str, conn) catch unreachable;
 
-            std.log.debug("Connection established to {}", .{self.address});
+            std.log.info("Connection established to {s}", .{address_str});
 
             const stream_ctx = self.network_switch.allocator.create(StreamCallbackCtx) catch unreachable;
             stream_ctx.* = StreamCallbackCtx{
@@ -225,7 +230,7 @@ pub const Switch = struct {
 
     pub fn newStream(
         self: *Switch,
-        address: std.net.Address,
+        address: Multiaddr,
         proposed_protocols: []const []const u8,
         callback_ctx: ?*anyopaque,
         callback: *const fn (callback_ctx: ?*anyopaque, controller: anyerror!?*anyopaque) void,
@@ -234,7 +239,11 @@ pub const Switch = struct {
             callback(callback_ctx, error.SwitchStopped);
             return;
         }
-        const address_str = std.fmt.allocPrint(self.allocator, "{}", .{address}) catch unreachable;
+        const address_str = address.toString(self.allocator) catch |err| {
+            std.log.warn("Failed to convert address to string: {}", .{err});
+            callback(callback_ctx, err);
+            return;
+        };
         defer self.allocator.free(address_str);
 
         // Check if the connection already exists.

--- a/src/switch.zig
+++ b/src/switch.zig
@@ -273,7 +273,7 @@ pub const Switch = struct {
 
     pub fn listen(
         self: *Switch,
-        address: std.net.Address,
+        address: Multiaddr,
         callback_ctx: ?*anyopaque,
         callback: *const fn (callback_ctx: ?*anyopaque, controller: anyerror!?*anyopaque) void,
     ) !void {

--- a/src/thread_event_loop.zig
+++ b/src/thread_event_loop.zig
@@ -7,6 +7,7 @@ const Future = @import("concurrent/future.zig").Future;
 const conn = @import("conn.zig");
 const xev_tcp = libp2p.transport.tcp;
 const quic = libp2p.transport.quic;
+const Multiaddr = @import("multiformats").multiaddr.Multiaddr;
 
 /// Memory pool for managing completion objects in the event loop.
 const CompletionPool = std.heap.MemoryPool(xev.Completion);
@@ -85,7 +86,7 @@ pub const IOAction = union(enum) {
     quic_engine_start: struct {
         engine: *quic.QuicEngine,
     },
-    quic_connect: struct { engine: *quic.QuicEngine, peer_address: std.net.Address, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*quic.QuicConnection) void },
+    quic_connect: struct { engine: *quic.QuicEngine, peer_address: Multiaddr, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*quic.QuicConnection) void },
     quic_close_connection: struct {
         conn: *quic.QuicConnection,
         callback_ctx: ?*anyopaque,

--- a/src/transport/quic.zig
+++ b/src/transport/quic.zig
@@ -656,9 +656,10 @@ pub const QuicListener = struct {
     /// Starts listening for incoming QUIC connections on the specified address.
     /// It initializes a UDP socket, binds it to the address, and starts the QUIC engine.
     /// If the listener is already started, it returns an error.
-    pub fn listen(self: *QuicListener, address: std.net.Address) ListenError!void {
-        const socket = try UDP.init(address);
-        try socket.bind(address);
+    pub fn listen(self: *QuicListener, address: Multiaddr) ListenError!void {
+        const addrAndPeerId = try maToStdAddrAndPeerId(address);
+        const socket = try UDP.init(addrAndPeerId.address);
+        try socket.bind(addrAndPeerId.address);
 
         self.engine = undefined;
         const engine_ptr = &self.engine.?;
@@ -1195,8 +1196,8 @@ test "lsquic transport dialing and listening" {
     }.callback);
     defer listener.deinit();
 
-    const addr = try std.net.Address.parseIp4("127.0.0.1", 9997);
-
+    var addr = try Multiaddr.fromString(std.testing.allocator, "/ip4/0.0.0.0/udp/9997");
+    defer addr.deinit();
     try listener.listen(addr);
 
     var loop: io_loop.ThreadEventLoop = undefined;

--- a/src/transport/quic.zig
+++ b/src/transport/quic.zig
@@ -15,6 +15,9 @@ const Allocator = std.mem.Allocator;
 const UDP = xev.UDP;
 const posix = std.posix;
 const protoMsgHandler = libp2p.protocols.AnyProtocolMessageHandler;
+const multiaddr = @import("multiformats").multiaddr;
+const Multiaddr = multiaddr.Multiaddr;
+const PeerId = @import("peer_id").PeerId;
 
 // Maximum stream data for bidirectional streams
 const MaxStreamDataBidiRemote = 64 * 1024 * 1024; // 64 MB
@@ -173,8 +176,20 @@ pub const QuicEngine = struct {
     /// If the connection fails, it invokes the callback with an error.
     /// This function is called from the event loop thread to ensure thread safety.
     /// It should not be called directly from other threads.
-    pub fn doConnect(self: *QuicEngine, peer_address: std.net.Address, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*QuicConnection) void) void {
+    pub fn doConnect(self: *QuicEngine, peer_address: Multiaddr, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*QuicConnection) void) void {
+        const addrAndPeerId = maToStdAddrAndPeerId(peer_address) catch |err| {
+            std.log.warn("Failed to convert Multiaddr to std.net.Address and PeerId: {}", .{err});
+            callback(callback_ctx, err);
+            return;
+        };
+
+        if (addrAndPeerId.peer_id == null) {
+            callback(callback_ctx, error.NoPeerIdFound);
+            return;
+        }
+
         self.connect_ctx = .{
+            .peer_id = addrAndPeerId.peer_id.?,
             .address = peer_address,
             .callback_ctx = callback_ctx,
             .callback = callback,
@@ -186,7 +201,7 @@ pub const QuicEngine = struct {
             self.engine,
             lsquic.N_LSQVER,
             @ptrCast(&self.local_address.any),
-            @ptrCast(&peer_address.any),
+            @ptrCast(&addrAndPeerId.address.any),
             self,
             null,
             null,
@@ -206,7 +221,7 @@ pub const QuicEngine = struct {
     /// If the connection fails, it invokes the callback with an error.
     /// This function is not thread-safe and should not be called from multiple threads concurrently.
     /// Queueuing this operation is recommended.
-    pub fn connect(self: *QuicEngine, peer_address: std.net.Address, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*QuicConnection) void) void {
+    pub fn connect(self: *QuicEngine, peer_address: Multiaddr, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*QuicConnection) void) void {
         if (self.connect_ctx != null) {
             callback(callback_ctx, error.AlreadyConnecting);
             return;
@@ -376,7 +391,8 @@ pub const QuicConnection = struct {
     };
 
     pub const ConnectCtx = struct {
-        address: std.net.Address,
+        peer_id: PeerId,
+        address: Multiaddr,
         callback_ctx: ?*anyopaque,
         callback: *const fn (ctx: ?*anyopaque, res: anyerror!*QuicConnection) void,
     };
@@ -723,7 +739,7 @@ pub const QuicTransport = struct {
     /// If the connection fails, it invokes the callback with an error.
     /// This is not thread-safe and should not be called from multiple threads concurrently.
     /// Queueuing this operation is recommended.
-    pub fn dial(self: *QuicTransport, peer_address: std.net.Address, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*QuicConnection) void) void {
+    pub fn dial(self: *QuicTransport, peer_address: Multiaddr, callback_ctx: ?*anyopaque, callback: *const fn (ctx: ?*anyopaque, res: anyerror!*QuicConnection) void) void {
         var dialer = self.getOrCreateDialer(peer_address) catch |err| {
             callback(callback_ctx, err);
             return;
@@ -741,36 +757,40 @@ pub const QuicTransport = struct {
         return listener;
     }
 
-    fn getOrCreateDialer(self: *QuicTransport, peer_address: std.net.Address) !*QuicEngine {
-        switch (peer_address.any.family) {
-            posix.AF.INET => {
-                if (self.dialer_v4) |*dialer| {
-                    return dialer;
-                }
-                const bind_addr = try std.net.Address.parseIp4("0.0.0.0", 0);
-                const socket = try UDP.init(bind_addr);
-                try socket.bind(bind_addr);
+    fn getOrCreateDialer(self: *QuicTransport, peer_address: Multiaddr) !*QuicEngine {
+        var iter = peer_address.iterator();
+        while (try iter.next()) |p| {
+            switch (p) {
+                .Ip4 => {
+                    if (self.dialer_v4) |*dialer| {
+                        return dialer;
+                    }
+                    const bind_addr = try std.net.Address.parseIp4("0.0.0.0", 0);
+                    const socket = try UDP.init(bind_addr);
+                    try socket.bind(bind_addr);
 
-                self.dialer_v4 = undefined;
-                const engine_ptr = &self.dialer_v4.?;
-                try engine_ptr.init(self.allocator, socket, self, true);
-                return engine_ptr;
-            },
-            posix.AF.INET6 => {
-                if (self.dialer_v6) |*dialer| {
-                    return dialer;
-                }
-                const bind_addr = try std.net.Address.parseIp6("::", 0);
-                const socket = try UDP.init(bind_addr);
-                try socket.bind(bind_addr);
+                    self.dialer_v4 = undefined;
+                    const engine_ptr = &self.dialer_v4.?;
+                    try engine_ptr.init(self.allocator, socket, self, true);
+                    return engine_ptr;
+                },
+                .Ip6 => {
+                    if (self.dialer_v6) |*dialer| {
+                        return dialer;
+                    }
+                    const bind_addr = try std.net.Address.parseIp6("::", 0);
+                    const socket = try UDP.init(bind_addr);
+                    try socket.bind(bind_addr);
 
-                self.dialer_v6 = undefined;
-                const engine_ptr = &self.dialer_v6.?;
-                try engine_ptr.init(self.allocator, socket, self, true);
-                return engine_ptr;
-            },
-            else => return error.UnsupportedAddressFamily,
+                    self.dialer_v6 = undefined;
+                    const engine_ptr = &self.dialer_v6.?;
+                    try engine_ptr.init(self.allocator, socket, self, true);
+                    return engine_ptr;
+                },
+                else => continue,
+            }
         }
+        return error.UnsupportedAddressFamily;
     }
 
     fn initSslContext(subject_key: *ssl.EVP_PKEY, cert: *ssl.X509) !*ssl.SSL_CTX {
@@ -1048,6 +1068,43 @@ fn onStreamClose(
     self.conn.engine.allocator.destroy(self);
 }
 
+fn maToStdAddrAndPeerId(ma: Multiaddr) !struct { address: std.net.Address, peer_id: ?PeerId } {
+    var iter = ma.iterator();
+    var ip_addr: ?std.net.Address = null;
+    var port: ?u16 = null;
+    var peer_id: ?PeerId = null;
+
+    while (try iter.next()) |protocol| {
+        switch (protocol) {
+            .Ip4 => |ip4| {
+                ip_addr = .{ .in = ip4 };
+            },
+            .Ip6 => |ip6| {
+                ip_addr = .{ .in6 = ip6 };
+            },
+            .Udp => |udp_port| {
+                port = udp_port;
+            },
+            .P2P => |p2p_id| {
+                peer_id = p2p_id;
+            },
+            else => continue,
+        }
+    }
+
+    if (ip_addr == null) {
+        return error.NoIPAddressFound;
+    }
+
+    if (port == null) {
+        return error.NoPortFound;
+    }
+
+    var result = ip_addr.?;
+    result.setPort(port.?);
+    return .{ .address = result, .peer_id = peer_id };
+}
+
 test "lsquic transport initialization" {
     var loop: io_loop.ThreadEventLoop = undefined;
     try loop.init(std.testing.allocator);
@@ -1116,6 +1173,10 @@ test "lsquic transport dialing and listening" {
 
     defer ssl.EVP_PKEY_free(server_key);
 
+    var pubkey = try tls.createProtobufEncodedPublicKey1(std.testing.allocator, server_key);
+    defer std.testing.allocator.free(pubkey.data.?);
+    const server_peer_id = try PeerId.fromPublicKey(std.testing.allocator, &pubkey);
+
     var server: QuicTransport = undefined;
     try server.init(&server_loop, server_key, keys_proto.KeyType.ECDSA, std.testing.allocator);
 
@@ -1182,7 +1243,10 @@ test "lsquic transport dialing and listening" {
         .conn = undefined,
         .notify = .{},
     };
-    transport.dial(addr, &dial_ctx, DialCtx.callback);
+    var dial_ma = try Multiaddr.fromString(std.testing.allocator, "/ip4/127.0.0.1/udp/9997");
+    try dial_ma.push(.{ .P2P = server_peer_id });
+    defer dial_ma.deinit();
+    transport.dial(dial_ma, &dial_ctx, DialCtx.callback);
     dial_ctx.notify.wait();
 
     dial_ctx.conn.close(null, struct {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Zig-libp2p project, focusing on dependency management, build configuration, and protocol/address handling in tests. The most significant changes include adding the `peer-id` dependency and integrating it throughout the build and test code, updating workflow and cache actions for CI, and refactoring protocol tests to use multiaddresses and peer IDs for more realistic network simulation.

### Dependency and Build System Updates

* Added the `peer-id` package as a dependency in `build.zig.zon` and integrated its module into the build system (`build.zig`), making it available to the main library, executable, and unit tests. [[1]](diffhunk://#diff-12dc677c49af0bd162081512eac1adca6ec6040095aeaaa59cb9f931abccefc9R44-R47) [[2]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR56-R61) [[3]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR72) [[4]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR97) [[5]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR142-R143) [[6]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR161-R162)
* Updated the `zmultiformats` dependency to use a specific commit hash, improving reproducibility.

### CI Workflow Improvements

* Upgraded GitHub Actions workflow versions from v3 to v4 for both `actions/checkout` and `actions/cache`, and renamed the workflow for clarity. [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L1-R1) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L17-R21) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L36-R37)
* Changed the Zig build optimization flag from `ReleaseFast` to `ReleaseSafe` for safer builds.

### Protocol and Address Handling Refactor

* Refactored protocol tests in `src/protocols/discard.zig` to use `Multiaddr` and `PeerId` for addresses instead of raw IP addresses, enabling more accurate libp2p-style network simulation and peer identification. [[1]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcR10-R11) [[2]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcL241-R244) [[3]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcR324-R329) [[4]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcL341-R352) [[5]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcL365-R377) [[6]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcR386-R389) [[7]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcL427-R446) [[8]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcL481-R501) [[9]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcR512-R515) [[10]](diffhunk://#diff-ff316f670c598abd803f1c58efce6e9e0d17561d397ce072cff121037079f6dcR581-R586)

### PeerId and TLS API Changes

* Renamed `PeerId.fromPublicKey` to `PeerId.fromKeyPair` and updated its usage throughout the codebase for clarity and correctness; added new utility methods for base58 encoding and string parsing. [[1]](diffhunk://#diff-81453ac8687a8654be48a2bd29ec5fe099f7fdfebe9a1895ad0784069bec3e72L48-R52) [[2]](diffhunk://#diff-81453ac8687a8654be48a2bd29ec5fe099f7fdfebe9a1895ad0784069bec3e72R117) [[3]](diffhunk://#diff-81453ac8687a8654be48a2bd29ec5fe099f7fdfebe9a1895ad0784069bec3e72R160) [[4]](diffhunk://#diff-81453ac8687a8654be48a2bd29ec5fe099f7fdfebe9a1895ad0784069bec3e72L173-R175) [[5]](diffhunk://#diff-81453ac8687a8654be48a2bd29ec5fe099f7fdfebe9a1895ad0784069bec3e72L191-R193) [[6]](diffhunk://#diff-81453ac8687a8654be48a2bd29ec5fe099f7fdfebe9a1895ad0784069bec3e72L304-R306)
* Refactored TLS public key encoding functions to provide both raw byte buffer and protobuf struct variants, improving API clarity and usability. [[1]](diffhunk://#diff-9b2c7de0858c9cdf38214981cb4d3d4b16a1ee8208caa876ffe4ebca18db69beL165-R166) [[2]](diffhunk://#diff-9b2c7de0858c9cdf38214981cb4d3d4b16a1ee8208caa876ffe4ebca18db69beL191-L193) [[3]](diffhunk://#diff-9b2c7de0858c9cdf38214981cb4d3d4b16a1ee8208caa876ffe4ebca18db69beR5)

These changes collectively improve dependency management, test realism, and code clarity, setting the stage for further protocol development and testing. 

fix #17 