### PR TITLE
feat: support libp2p cert verification

### DIFF
--- a/src/protocols/discard.zig
+++ b/src/protocols/discard.zig
@@ -9,6 +9,7 @@ const keys_proto = libp2p.protobuf.keys;
 const tls = libp2p.security.tls;
 const Multiaddr = @import("multiformats").multiaddr.Multiaddr;
 const PeerId = @import("peer_id").PeerId;
+const keys = @import("peer_id").keys;
 
 pub const DiscardProtocolHandler = struct {
     allocator: std.mem.Allocator,
@@ -238,22 +239,132 @@ pub const DiscardSender = struct {
     }
 };
 
+const TestNewStreamCallback = struct {
+    mutex: std.Thread.ResetEvent,
+
+    sender: *DiscardSender,
+
+    const Self = @This();
+    pub fn callback(ctx: ?*anyopaque, res: anyerror!?*anyopaque) void {
+        const self: *Self = @ptrCast(@alignCast(ctx.?));
+        const sender_ptr = res catch {
+            self.mutex.set();
+            return;
+        };
+        self.sender = @ptrCast(@alignCast(sender_ptr.?));
+        self.mutex.set();
+    }
+};
+
+fn spawnSwitch3Test(allocator: std.mem.Allocator, switch3: *swarm.Switch, server_peer_id: PeerId) !void {
+    var callback2: TestNewStreamCallback = .{ .mutex = .{}, .sender = undefined };
+
+    var dial_ma2 = try Multiaddr.fromString(allocator, "/ip4/127.0.0.1/udp/8767");
+    defer dial_ma2.deinit();
+    try dial_ma2.push(.{ .P2P = server_peer_id });
+
+    switch3.newStream(
+        dial_ma2,
+        &.{"discard"},
+        &callback2,
+        TestNewStreamCallback.callback,
+    );
+
+    callback2.mutex.wait();
+
+    callback2.sender.send("Hello from Switch 3", null, struct {
+        pub fn callback_(_: ?*anyopaque, res: anyerror!usize) void {
+            if (res) |size| {
+                std.debug.print("Message from Switch 3 sent successfully, size: {}\n", .{size});
+            } else |err| {
+                std.debug.print("Failed to send message from Switch 3: {}\n", .{err});
+            }
+        }
+    }.callback_);
+
+    std.time.sleep(3000 * std.time.ns_per_ms);
+}
+
+fn spawnMultipleClientsTest(allocator: std.mem.Allocator, server_peer_id: PeerId, client_id: u32) !void {
+    var cl_loop: io_loop.ThreadEventLoop = undefined;
+    try cl_loop.init(allocator);
+    defer cl_loop.deinit();
+
+    const cl_host_key = try tls.generateKeyPair1(keys.KeyType.ED25519);
+    defer ssl.EVP_PKEY_free(cl_host_key);
+
+    var cl_transport: quic.QuicTransport = undefined;
+    try cl_transport.init(&cl_loop, cl_host_key, keys_proto.KeyType.ED25519, allocator);
+
+    var client_switch: swarm.Switch = undefined;
+    client_switch.init(allocator, &cl_transport);
+    defer client_switch.deinit();
+
+    var discard_handler = DiscardProtocolHandler.init(allocator);
+    defer discard_handler.deinit();
+    try client_switch.addProtocolHandler("discard", discard_handler.any());
+
+    std.time.sleep(100 * std.time.ns_per_ms * client_id);
+
+    var callback: TestNewStreamCallback = .{ .mutex = .{}, .sender = undefined };
+
+    var dial_ma = try Multiaddr.fromString(allocator, "/ip4/127.0.0.1/udp/9000");
+    defer dial_ma.deinit();
+    try dial_ma.push(.{ .P2P = server_peer_id });
+
+    client_switch.newStream(
+        dial_ma,
+        &.{"discard"},
+        &callback,
+        TestNewStreamCallback.callback,
+    );
+
+    callback.mutex.wait();
+
+    for (0..5) |msg_id| {
+        const message = try std.fmt.allocPrint(allocator, "Hello from Client {} - Message {}", .{ client_id, msg_id });
+        defer allocator.free(message);
+
+        callback.sender.send(message, null, struct {
+            fn callback_(_: ?*anyopaque, res: anyerror!usize) void {
+                if (res) |size| {
+                    std.debug.print("Client message sent successfully, size: {}\n", .{size});
+                } else |err| {
+                    std.debug.print("Failed to send client message: {}\n", .{err});
+                }
+            }
+        }.callback_);
+
+        std.time.sleep(50 * std.time.ns_per_ms);
+    }
+
+    std.time.sleep(3000 * std.time.ns_per_ms);
+}
+
 test "discard protocol using switch" {
-    const allocator = std.testing.allocator;
+    var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = true }){};
+    defer {
+        const leaked = gpa.deinit();
+        if (leaked == .leak) {
+            std.log.warn("Memory leak detected in test!", .{});
+        }
+    }
+    const allocator = gpa.allocator();
+
     const switch1_listen_address = try Multiaddr.fromString(allocator, "/ip4/0.0.0.0/udp/8767");
     defer switch1_listen_address.deinit();
 
     var loop: io_loop.ThreadEventLoop = undefined;
-    try loop.init(std.testing.allocator);
+    try loop.init(allocator);
     defer {
         loop.deinit();
     }
 
-    const host_key = try tls.generateKeyPair(keys_proto.KeyType.ED25519);
+    const host_key = try tls.generateKeyPair1(keys.KeyType.ED25519);
     defer ssl.EVP_PKEY_free(host_key);
 
     var transport: quic.QuicTransport = undefined;
-    try transport.init(&loop, host_key, keys_proto.KeyType.ED25519, std.testing.allocator);
+    try transport.init(&loop, host_key, keys_proto.KeyType.ED25519, allocator); // ✅ 使用统一分配器
 
     var pubkey = try tls.createProtobufEncodedPublicKey1(allocator, host_key);
     defer allocator.free(pubkey.data.?);
@@ -284,7 +395,7 @@ test "discard protocol using switch" {
         cl_loop.deinit();
     }
 
-    const cl_host_key = try tls.generateKeyPair(keys_proto.KeyType.ED25519);
+    const cl_host_key = try tls.generateKeyPair1(keys.KeyType.ED25519);
     defer ssl.EVP_PKEY_free(cl_host_key);
 
     var cl_transport: quic.QuicTransport = undefined;
@@ -306,7 +417,7 @@ test "discard protocol using switch" {
         cl_loop1.deinit();
     }
 
-    const cl_host_key1 = try tls.generateKeyPair(keys_proto.KeyType.ED25519);
+    const cl_host_key1 = try tls.generateKeyPair1(keys.KeyType.ED25519);
     defer ssl.EVP_PKEY_free(cl_host_key1);
 
     var cl_transport1: quic.QuicTransport = undefined;
@@ -330,6 +441,7 @@ test "discard protocol using switch" {
     var dial_ma = try Multiaddr.fromString(allocator, "/ip4/127.0.0.1/udp/8767");
     try dial_ma.push(.{ .P2P = server_peer_id });
     defer dial_ma.deinit();
+
     switch2.newStream(
         dial_ma,
         &.{"discard"},
@@ -373,57 +485,12 @@ test "discard protocol using switch" {
         }
     }.callback_);
 
-    // spawn a thread use switch3 new another stream
+    std.time.sleep(500 * std.time.ns_per_ms);
+
     const thread = try std.Thread.spawn(.{}, spawnSwitch3Test, .{ allocator, &switch3, server_peer_id });
     defer thread.join();
 
-    std.time.sleep(2000 * std.time.ns_per_ms); // Wait for the stream to be established
-
-}
-
-const TestNewStreamCallback = struct {
-    mutex: std.Thread.ResetEvent,
-
-    sender: *DiscardSender,
-
-    const Self = @This();
-    pub fn callback(ctx: ?*anyopaque, res: anyerror!?*anyopaque) void {
-        const self: *Self = @ptrCast(@alignCast(ctx.?));
-        const sender_ptr = res catch {
-            self.mutex.set();
-            return;
-        };
-        self.sender = @ptrCast(@alignCast(sender_ptr.?));
-        std.log.info("Stream started successfully", .{});
-        self.mutex.set();
-    }
-};
-
-fn spawnSwitch3Test(allocator: std.mem.Allocator, switch3: *swarm.Switch, server_peer_id: PeerId) !void {
-    var callback2: TestNewStreamCallback = .{ .mutex = .{}, .sender = undefined };
-
-    var dial_ma2 = try Multiaddr.fromString(allocator, "/ip4/127.0.0.1/udp/8777");
-    defer dial_ma2.deinit();
-    try dial_ma2.push(.{ .P2P = server_peer_id });
-
-    switch3.newStream(
-        dial_ma2,
-        &.{"discard"},
-        &callback2,
-        TestNewStreamCallback.callback,
-    );
-
-    callback2.mutex.wait();
-
-    callback2.sender.send("Hello from Switch 3", null, struct {
-        pub fn callback_(_: ?*anyopaque, res: anyerror!usize) void {
-            if (res) |size| {
-                std.debug.print("Message sent successfully, size: {}\n", .{size});
-            } else |err| {
-                std.debug.print("Failed to send message: {}\n", .{err});
-            }
-        }
-    }.callback_);
+    std.time.sleep(2000 * std.time.ns_per_ms);
 }
 
 test "discard protocol using switch with 1MB data" {
@@ -476,23 +543,6 @@ test "discard protocol using switch with 1MB data" {
     var discard_handler2 = DiscardProtocolHandler.init(allocator);
     defer discard_handler2.deinit();
     try switch2.addProtocolHandler("discard", discard_handler2.any());
-
-    // const TestNewStreamCallback = struct {
-    //     mutex: std.Thread.ResetEvent,
-    //     sender: *DiscardSender,
-
-    //     const Self = @This();
-    //     pub fn callback(ctx: ?*anyopaque, res: anyerror!?*anyopaque) void {
-    //         const self: *Self = @ptrCast(@alignCast(ctx.?));
-    //         const sender_ptr = res catch |err| {
-    //             std.log.warn("Failed to start stream: {}", .{err});
-    //             self.mutex.set();
-    //             return;
-    //         };
-    //         self.sender = @ptrCast(@alignCast(sender_ptr.?));
-    //         self.mutex.set();
-    //     }
-    // };
 
     var callback: TestNewStreamCallback = .{ .mutex = .{}, .sender = undefined };
     var dial_ma = try Multiaddr.fromString(allocator, "/ip4/127.0.0.1/udp/8777");
@@ -609,26 +659,7 @@ test "no supported protocols error" {
 
     var discard_handler2 = DiscardProtocolHandler.init(allocator);
     defer discard_handler2.deinit();
-    // try switch2.addProtocolHandler("discard", discard_handler2.any());
 
-    // const TestNewStreamCallback = struct {
-    //     mutex: std.Thread.ResetEvent,
-
-    //     sender: *DiscardSender,
-
-    //     const Self = @This();
-    //     pub fn callback(ctx: ?*anyopaque, res: anyerror!?*anyopaque) void {
-    //         const self: *Self = @ptrCast(@alignCast(ctx.?));
-    //         const sender_ptr = res catch |err| {
-    //             std.testing.expectEqual(error.NoSupportedProtocols, err) catch unreachable;
-    //             self.mutex.set();
-    //             return;
-    //         };
-    //         self.sender = @ptrCast(@alignCast(sender_ptr.?));
-    //         std.log.info("Stream started successfully", .{});
-    //         self.mutex.set();
-    //     }
-    // };
     var callback: TestNewStreamCallback = .{
         .mutex = .{},
         .sender = undefined,
@@ -648,4 +679,59 @@ test "no supported protocols error" {
 
     std.time.sleep(2000 * std.time.ns_per_ms); // Wait for the stream to be established
 
+}
+
+test "discard protocol with 5 concurrent clients" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = true }){};
+    defer {
+        const leaked = gpa.deinit();
+        if (leaked == .leak) {
+            std.log.warn("Memory leak detected in test!", .{});
+        }
+    }
+    const allocator = gpa.allocator();
+
+    const switch1_listen_address = try Multiaddr.fromString(allocator, "/ip4/0.0.0.0/udp/9000");
+    defer switch1_listen_address.deinit();
+
+    var loop: io_loop.ThreadEventLoop = undefined;
+    try loop.init(allocator);
+    defer loop.deinit();
+
+    const host_key = try tls.generateKeyPair1(keys.KeyType.ED25519);
+    defer ssl.EVP_PKEY_free(host_key);
+
+    var transport: quic.QuicTransport = undefined;
+    try transport.init(&loop, host_key, keys_proto.KeyType.ED25519, allocator);
+
+    var pubkey = try tls.createProtobufEncodedPublicKey1(allocator, host_key);
+    defer allocator.free(pubkey.data.?);
+    const server_peer_id = try PeerId.fromPublicKey(allocator, &pubkey);
+
+    var switch1: swarm.Switch = undefined;
+    switch1.init(allocator, &transport);
+    defer switch1.deinit();
+
+    var discard_handler = DiscardProtocolHandler.init(allocator);
+    defer discard_handler.deinit();
+    try switch1.addProtocolHandler("discard", discard_handler.any());
+
+    try switch1.listen(switch1_listen_address, null, struct {
+        pub fn callback(_: ?*anyopaque, _: anyerror!?*anyopaque) void {}
+    }.callback);
+
+    std.time.sleep(500 * std.time.ns_per_ms);
+
+    const NUM_CLIENTS = 5;
+    var threads: [NUM_CLIENTS]std.Thread = undefined;
+
+    for (0..NUM_CLIENTS) |i| {
+        threads[i] = try std.Thread.spawn(.{}, spawnMultipleClientsTest, .{ allocator, server_peer_id, @as(u32, @intCast(i)) });
+    }
+
+    for (0..NUM_CLIENTS) |i| {
+        threads[i].join();
+    }
+
+    std.time.sleep(2000 * std.time.ns_per_ms);
 }

--- a/src/protocols/discard.zig
+++ b/src/protocols/discard.zig
@@ -364,7 +364,7 @@ test "discard protocol using switch" {
     defer ssl.EVP_PKEY_free(host_key);
 
     var transport: quic.QuicTransport = undefined;
-    try transport.init(&loop, host_key, keys_proto.KeyType.ED25519, allocator); // ✅ 使用统一分配器
+    try transport.init(&loop, host_key, keys_proto.KeyType.ED25519, allocator);
 
     var pubkey = try tls.createProtobufEncodedPublicKey1(allocator, host_key);
     defer allocator.free(pubkey.data.?);
@@ -450,6 +450,7 @@ test "discard protocol using switch" {
     );
 
     callback.mutex.wait();
+    try std.testing.expect(callback.sender.stream.conn.security_session.?.remote_id.eql(&server_peer_id));
 
     callback.sender.send("Hello from Switch 2", null, struct {
         pub fn callback_(_: ?*anyopaque, res: anyerror!usize) void {
@@ -475,6 +476,7 @@ test "discard protocol using switch" {
 
     callback1.mutex.wait();
 
+    try std.testing.expect(callback1.sender.stream.conn.security_session.?.remote_id.eql(&server_peer_id));
     callback1.sender.send("Hello from Switch 2 (second message)", null, struct {
         pub fn callback_(_: ?*anyopaque, res: anyerror!usize) void {
             if (res) |size| {

--- a/src/security.zig
+++ b/src/security.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const PeerId = @import("peer_id").PeerId;
+const PublicKey = @import("peer_id").PublicKey;
 
 pub const plain = @import("security/plain.zig");
 pub const insecure = @import("security/insecure.zig");
@@ -8,4 +10,10 @@ pub const Session = struct {
     local_id: []const u8,
     remote_id: []const u8,
     remote_public_key: []const u8,
+};
+
+pub const Session1 = struct {
+    local_id: PeerId,
+    remote_id: PeerId,
+    remote_public_key: PublicKey,
 };

--- a/src/security/tls.zig
+++ b/src/security/tls.zig
@@ -18,6 +18,12 @@ const CertNotBeforeOffsetSeconds = -3600; // 1 hour before current time
 /// The offset to apply to the certificate's notAfter field.
 const CertNotAfterOffsetSeconds = 365 * 24 * 3600; // 1 year after current time
 
+// There is no approach to get cert in the lsquic `onHskDone` callback, but we need it to verify the peer's identity.
+// So we store it in a thread-local variable. It assumes that the callback will be called in the same thread for each engine,
+// and that multiple connections will not be handled concurrently in the same thread.
+// cpp-libp2p fork the lsquic library and add a function to retrieve the peer certificate.
+// https://github.com/libp2p/cpp-libp2p/blob/c386b481410af1910c23f96aec81789410204dbd/vcpkg-overlay/liblsquic/lsquic_conn_ssl.patch .
+// TODO: If thread-local storage is not suitable, consider apply that patch.
 threadlocal var g_peer_cert: ?*ssl.X509 = null;
 
 pub const Error = error{

--- a/src/security/tls.zig
+++ b/src/security/tls.zig
@@ -18,7 +18,7 @@ const CertNotBeforeOffsetSeconds = -3600; // 1 hour before current time
 /// The offset to apply to the certificate's notAfter field.
 const CertNotAfterOffsetSeconds = 365 * 24 * 3600; // 1 year after current time
 
-var g_peer_cert: ?*ssl.X509 = null;
+threadlocal var g_peer_cert: ?*ssl.X509 = null;
 
 pub const Error = error{
     CertCreationFailed,
@@ -682,11 +682,10 @@ pub fn libp2pVerifyCallback(_: c_int, cert_ctx: ?*ssl.X509_STORE_CTX) callconv(.
         return 0;
     }
 
-    // if (g_peer_cert) |old_cert| {
-    //     ssl.X509_free(old_cert);
-    // }
-    // g_peer_cert = ssl.X509_dup(cert.?);
-    // std.log.debug("Saved certificate to global variable: {*}", .{g_peer_cert});
+    if (g_peer_cert) |old_cert| {
+        ssl.X509_free(old_cert);
+    }
+    g_peer_cert = ssl.X509_dup(cert.?);
 
     var subject_name: [256]u8 = std.mem.zeroes([256]u8);
     const subject_name_ptr = ssl.X509_get_subject_name(cert);

--- a/src/transport/quic.zig
+++ b/src/transport/quic.zig
@@ -813,8 +813,7 @@ pub const QuicTransport = struct {
         // This callback is used to verify the peer's certificate.
         // It is set to verify the peer's certificate and fail if no peer certificate is provided.
         // It also sets the callback for certificate verification.
-        ssl.SSL_CTX_set_verify(ssl_ctx, ssl.SSL_VERIFY_PEER | ssl.SSL_VERIFY_FAIL_IF_NO_PEER_CERT | ssl.SSL_VERIFY_CLIENT_ONCE, null);
-        ssl.SSL_CTX_set_cert_verify_callback(ssl_ctx, tls.libp2pVerifyCallback, null);
+        ssl.SSL_CTX_set_verify(ssl_ctx, ssl.SSL_VERIFY_PEER | ssl.SSL_VERIFY_FAIL_IF_NO_PEER_CERT | ssl.SSL_VERIFY_CLIENT_ONCE, tls.libp2pVerifyCallback);
 
         // Set the certificate algorithm preferences for the SSL context.
         if (ssl.SSL_CTX_set_verify_algorithm_prefs(ssl_ctx, SignatureAlgs.ptr, @intCast(SignatureAlgs.len)) == 0)


### PR DESCRIPTION
This pull request adds new functionality for verifying and extracting peer information from X.509 certificates in the TLS security module. It introduces robust parsing and validation of custom certificate extensions, as well as utility functions for key reconstruction and signature verification. Additionally, the changes are tested with a new unit test for Ed25519 certificates.

**Certificate Verification and Extension Parsing:**

* Added `verifyAndExtractPeerInfo` function to validate certificates, extract the host public key and peer ID, and verify the signature from a custom libp2p extension.
* Implemented `extractExtensionFields` and `parseExtensionSequence` to parse ASN.1 SEQUENCE data from certificate extensions, retrieving both the host public key and signature.

**Key Handling and Signature Verification:**

* Added `reconstructEvpKeyFromPublicKey` to rebuild an OpenSSL key from raw public key bytes, supporting multiple key types.
* Introduced `verifySignature` to check signatures against extracted public keys and certificate data.

**Error Handling and Data Structures:**

* Added new error type `IncompatibleCertificateExtension` and the `ExtensionData` struct for extension parsing results.

**Testing:**

* Added a unit test to verify the certificate creation and validation process for Ed25519 keys, ensuring the new verification logic works as intended.

fix #38 