### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,6 @@
 name: Zig-libp2p CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/zen-eth/zig-libp2p/security/code-scanning/3](https://github.com/zen-eth/zig-libp2p/security/code-scanning/3)

To fix this issue, set the explicit `permissions` block in the workflow to limit the `GITHUB_TOKEN` permissions. The best practice is to add the block at the top level of the workflow (applies to all jobs), unless a job needs more privileges. This workflow only checks out code, caches dependencies and build outputs, runs formatting, testing, and build commands—none of which require write access to the repository or interactions with issues or pull requests—so the minimal permissions block should be `permissions: contents: read`. Insert this block after the `name` and before or after the `on:` block (either placement is valid, but after `name:` and before `on:` is common). No new methods, imports, or YAML keys are needed elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
